### PR TITLE
persist thumbnails to disk

### DIFF
--- a/resource/modules/AllTabs.jsm
+++ b/resource/modules/AllTabs.jsm
@@ -1,0 +1,25 @@
+'use strict';
+
+this.AllTabs = {
+	_events: {
+		attrModified: "TabAttrModified",
+		close: "TabClose",
+		move: "TabMove",
+		open: "TabOpen",
+		select: "TabSelect",
+		pinned: "TabPinned",
+		unpinned: "TabUnpinned"
+	},
+
+	get tabs() {
+		return Array.filter(gBrowser.tabs, tab => Utils.isValidXULTab(tab));
+	},
+
+	register: function(eventName, callback) {
+		Listeners.add(gBrowser.tabContainer, this._events[eventName], callback);
+	},
+
+	unregister: function(eventName, callback) {
+		Listeners.remove(gBrowser.tabContainer, this._events[eventName], callback);
+	}
+};

--- a/resource/modules/AllTabs.jsm
+++ b/resource/modules/AllTabs.jsm
@@ -1,4 +1,4 @@
-'use strict';
+// VERSION 1.0.0
 
 this.AllTabs = {
 	_events: {

--- a/resource/modules/TabItems.jsm
+++ b/resource/modules/TabItems.jsm
@@ -1,6 +1,4 @@
-// VERSION 1.0.6
-
-'use strict';
+// VERSION 1.0.7
 
 XPCOMUtils.defineLazyModuleGetter(this, "gPageThumbnails", "resource://gre/modules/PageThumbs.jsm", "PageThumbs");
 

--- a/resource/modules/TabItems.jsm
+++ b/resource/modules/TabItems.jsm
@@ -1189,13 +1189,13 @@ this.TabCanvas.prototype = Utils.extend(new Subscribable(), {
 			this._sendToSubscribers("painted");
 		});
 
-		this.persist(browser)
+		this.persist(browser);
 	},
 
 	persist(browser) {
 		// capture to file, thumbnail service does not persist automatically when rendering to canvas
 		gPageThumbnails.shouldStoreThumbnail(browser, () => {
-				gPageThumbnails.captureAndStoreIfStale(browser, () => {})
+			gPageThumbnails.captureAndStoreIfStale(browser, () => {})
 		})
 	},
 

--- a/resource/modules/TabItems.jsm
+++ b/resource/modules/TabItems.jsm
@@ -1192,11 +1192,20 @@ this.TabCanvas.prototype = Utils.extend(new Subscribable(), {
 		let h = this.canvas.height;
 		if(!w || !h) { return; }
 
-		gPageThumbnails.captureToCanvas(this.tab.linkedBrowser, this.canvas, () => {
+		let browser = this.tab.linkedBrowser;
+
+		gPageThumbnails.captureToCanvas(browser, this.canvas, () => {
 			this._sendToSubscribers("painted");
 		});
-		// also capture to file, thumbnail service does not persist automatically when rendering to canvas
-		gPageThumbnails.captureAndStoreIfStale(this.tab.linkedBrowser, () => {})
+
+		this.persist(browser)
+	},
+
+	persist(browser) {
+		// capture to file, thumbnail service does not persist automatically when rendering to canvas
+		gPageThumbnails.shouldStoreThumbnail(browser, () => {
+				gPageThumbnails.captureAndStoreIfStale(browser, () => {})
+		})
 	},
 
 	// Changing the dims of a canvas will clear it, so we don't want to do do this to a canvas we're currently displaying.
@@ -1205,7 +1214,10 @@ this.TabCanvas.prototype = Utils.extend(new Subscribable(), {
 		let temp = gPageThumbnails.createCanvas(window);
 		temp.width = aWidth;
 		temp.height = aHeight;
-		gPageThumbnails.captureToCanvas(this.tab.linkedBrowser, temp, () => {
+
+		let browser = this.tab.linkedBrowser;
+
+		gPageThumbnails.captureToCanvas(browser, temp, () => {
 			let ctx = this.canvas.getContext('2d');
 			this.canvas.width = aWidth;
 			this.canvas.height = aHeight;
@@ -1218,8 +1230,8 @@ this.TabCanvas.prototype = Utils.extend(new Subscribable(), {
 			}
 			this._sendToSubscribers("painted");
 		});
-		// also capture to file, thumbnail service does not persist automatically when rendering to canvas
-		gPageThumbnails.captureAndStoreIfStale(this.tab.linkedBrowser, () => {})
+
+		this.persist(browser);
 	},
 
 	toImageData: function() {

--- a/resource/modules/TabItems.jsm
+++ b/resource/modules/TabItems.jsm
@@ -656,13 +656,6 @@ this.TabItems = {
 		this.tabAspect = this.tabHeight / this.tabWidth;
 		this.invTabAspect = 1 / this.tabAspect;
 
-		this._thumbFileExpirationFilter = () => {
-			return AllTabs.tabs.map(t => t.linkedBrowser.currentURI.spec);
-		}
-
-
-		gPageThumbnails.addExpirationFilter(this._thumbFileExpirationFilter);
-
 		let $canvas = iQ("<canvas>").attr('moz-opaque', '');
 		$canvas.appendTo(iQ("body"));
 		$canvas.hide();
@@ -718,8 +711,6 @@ this.TabItems = {
 
 	uninit: function() {
 		Messenger.unlistenWindow(gWindow, "MozAfterPaint", this);
-
-		gPageThumbnails.removeExpirationFilter(this._thumbFileExpirationFilter);
 
 		for(let name in this._eventListeners) {
 			AllTabs.unregister(name, this._eventListeners[name]);

--- a/resource/modules/TabItems.jsm
+++ b/resource/modules/TabItems.jsm
@@ -1192,8 +1192,12 @@ this.TabCanvas.prototype = Utils.extend(new Subscribable(), {
 
 	persist(browser) {
 		// capture to file, thumbnail service does not persist automatically when rendering to canvas
-		gPageThumbnails.shouldStoreThumbnail(browser, () => {
-			gPageThumbnails.captureAndStoreIfStale(browser, () => {})
+		gPageThumbnails.shouldStoreThumbnail(browser, (storeAllowed) => {
+			if(storeAllowed) {
+				// ifStale bails out early if there already is an existing thumbnail less than 2 days old
+				// so this shouldn't cause excessive IO when a thumbnail is updated frequently
+				gPageThumbnails.captureAndStoreIfStale(browser, () => {})
+			}
 		})
 	},
 

--- a/resource/modules/TabView-frame.jsm
+++ b/resource/modules/TabView-frame.jsm
@@ -31,30 +31,6 @@ this.TabView = {
 	]
 };
 
-this.AllTabs = {
-	_events: {
-		attrModified: "TabAttrModified",
-		close: "TabClose",
-		move: "TabMove",
-		open: "TabOpen",
-		select: "TabSelect",
-		pinned: "TabPinned",
-		unpinned: "TabUnpinned"
-	},
-
-	get tabs() {
-		return Array.filter(gBrowser.tabs, tab => Utils.isValidXULTab(tab));
-	},
-
-	register: function(eventName, callback) {
-		Listeners.add(gBrowser.tabContainer, this._events[eventName], callback);
-	},
-
-	unregister: function(eventName, callback) {
-		Listeners.remove(gBrowser.tabContainer, this._events[eventName], callback);
-	}
-};
-
 Modules.LOADMODULE = function() {
 	// compatibility shims, for other add-ons to interact with this window more closely to the original if needed
 	for(let shim of TabView.shims) {
@@ -62,6 +38,7 @@ Modules.LOADMODULE = function() {
 		window.__defineGetter__(prop, function() { return self[prop]; });
 	}
 
+	Modules.load('AllTabs');
 	Modules.load('iQ');
 	Modules.load('Items');
 	Modules.load('GroupItems');
@@ -74,6 +51,7 @@ Modules.LOADMODULE = function() {
 };
 
 Modules.UNLOADMODULE = function() {
+	Modules.unload('AllTabs');
 	Modules.unload('UI');
 	Modules.unload('Search');
 	Modules.unload('Trench');

--- a/resource/modules/TabView-frame.jsm
+++ b/resource/modules/TabView-frame.jsm
@@ -1,4 +1,4 @@
-// VERSION 1.0.5
+// VERSION 1.0.6
 
 this.__defineGetter__('gWindow', function() { return window.parent; });
 this.__defineGetter__('gBrowser', function() { return gWindow.gBrowser; });

--- a/resource/modules/TabView.jsm
+++ b/resource/modules/TabView.jsm
@@ -1,6 +1,4 @@
-// VERSION 1.0.15
-
-'use strict';
+// VERSION 1.0.16
 
 this.__defineGetter__('gBrowser', function() { return window.gBrowser; });
 this.__defineGetter__('gTabViewDeck', function() { return $('tab-view-deck'); });


### PR DESCRIPTION
currently loading thumbnails from disk isn't really working because it depends on something (aero peek or the ctrl+tab preview?) persisting them to disk in the first place which is not always the case and often subject to expiration. 

Now the addon requests persistence and blocks expiration properly.