### PR TITLE
Fix element is undefined for some Firefox build without devconsole

### DIFF
--- a/resource/modules/UI.jsm
+++ b/resource/modules/UI.jsm
@@ -1,4 +1,4 @@
-// VERSION 1.3.28
+// VERSION 1.3.29
 
 // Used to scroll groups automatically, for instance when dragging a tab over a group's overflown edges.
 this.Synthesizer = {
@@ -1349,8 +1349,11 @@ this.UI = {
 			"newNavigator", "closeWindow", "undoCloseWindow",
 			"newNavigatorTab", "close", "undoCloseTab",
 			"undo", "redo", "cut", "copy", "paste",
-			"selectAll", "find", "browserConsole"
+			"selectAll", "find"
 		];
+		if(window.gDevTools) {
+			keyArray.push("browserConsole");
+		}
 		if(!WINNT) {
 			keyArray.push("quitApplication");
 			if(DARWIN) {
@@ -1359,17 +1362,15 @@ this.UI = {
 		}
 		for(let name of keyArray) {
 			let element = gWindow.document.getElementById("key_" + name);
-			if (element) {
-				let key = element.getAttribute('keycode') || element.getAttribute("key");
-				let modifiers = element.getAttribute('modifiers') || "";
-				this._browserKeys.push({
-					name: name,
-					key: Keysets.translateFromConstantCode(key),
-					accel: modifiers.includes('accel'),
-					alt: modifiers.includes('alt'),
-					shift: modifiers.includes('shift')
-				});
-			}
+			let key = element.getAttribute('keycode') || element.getAttribute("key");
+			let modifiers = element.getAttribute('modifiers') || "";
+			this._browserKeys.push({
+				name: name,
+				key: Keysets.translateFromConstantCode(key),
+				accel: modifiers.includes('accel'),
+				alt: modifiers.includes('alt'),
+				shift: modifiers.includes('shift')
+			});
 		}
 
 		// The following are handled by gBrowser._handleKeyDownEvent(): http://mxr.mozilla.org/mozilla-central/source/browser/base/content/tabbrowser.xml

--- a/resource/modules/UI.jsm
+++ b/resource/modules/UI.jsm
@@ -1359,15 +1359,17 @@ this.UI = {
 		}
 		for(let name of keyArray) {
 			let element = gWindow.document.getElementById("key_" + name);
-			let key = element.getAttribute('keycode') || element.getAttribute("key");
-			let modifiers = element.getAttribute('modifiers') || "";
-			this._browserKeys.push({
-				name: name,
-				key: Keysets.translateFromConstantCode(key),
-				accel: modifiers.includes('accel'),
-				alt: modifiers.includes('alt'),
-				shift: modifiers.includes('shift')
-			});
+			if (element) {
+				let key = element.getAttribute('keycode') || element.getAttribute("key");
+				let modifiers = element.getAttribute('modifiers') || "";
+				this._browserKeys.push({
+					name: name,
+					key: Keysets.translateFromConstantCode(key),
+					accel: modifiers.includes('accel'),
+					alt: modifiers.includes('alt'),
+					shift: modifiers.includes('shift')
+				});
+			}
 		}
 
 		// The following are handled by gBrowser._handleKeyDownEvent(): http://mxr.mozilla.org/mozilla-central/source/browser/base/content/tabbrowser.xml

--- a/resource/modules/UI.jsm
+++ b/resource/modules/UI.jsm
@@ -1351,7 +1351,7 @@ this.UI = {
 			"undo", "redo", "cut", "copy", "paste",
 			"selectAll", "find"
 		];
-		if(window.gDevTools) {
+		if(gWindow.gDevTools) {
 			keyArray.push("browserConsole");
 		}
 		if(!WINNT) {


### PR DESCRIPTION
Hi,

Firefox can be built without the developer tools (`--disable-devtools`, e.g. https://sourceforge.net/projects/lightfirefox/). This fixes the `element is undefined` error for the `key_browserConsole` id when firefox is built without the developer tools.